### PR TITLE
fix: add GITHUB_TOKEN permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Code Quality


### PR DESCRIPTION
## Summary
- Add explicit permissions block to CI workflow to address CodeQL security alert
- Follows GitHub security best practices for workflow token permissions

## Changes
- Added `permissions: contents: read` to CI workflow
- This limits the GITHUB_TOKEN to read-only access for repository contents
- Release workflow already has appropriate permissions configured

## Security Impact
✅ Resolves CodeQL alert: "Actions job or workflow does not limit the permissions of the GITHUB_TOKEN"
✅ Follows principle of least privilege for workflow permissions
✅ No functional changes to CI/CD pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)